### PR TITLE
Remove deprecation warning for django.conf.urls.url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ python:
 env:
   - DJANGO=1.11
   - DJANGO=2.2
-  - DJANGO=3.0
+  - DJANGO=3.2
 
 matrix:
   fast_finish: true
   exclude:
-    - { python: "3.5", env: DJANGO=3.0 }
+    - { python: "3.5", env: DJANGO=3.2 }
     - { python: "3.8", env: DJANGO=1.11 }
   include:
     - { python: "3.6", env: TOXENV=isort }

--- a/privates/admin.py
+++ b/privates/admin.py
@@ -1,8 +1,14 @@
-from django.conf.urls import url
+import django
 from django.contrib.auth import get_permission_codename
 
 from .views import PrivateMediaView
 from .widgets import PrivateFileWidget
+
+# django.conf.urls.url is deprecated
+if django.VERSION < (2, 0):
+    from django.conf.urls import url as re_path
+else:
+    from django.urls import re_path
 
 
 class PrivateMediaMixin:
@@ -62,7 +68,7 @@ class PrivateMediaMixin:
         for field in self.get_private_media_fields():
             view = self.get_private_media_view(field)
             extra.append(
-                url(
+                re_path(
                     r"^(?P<pk>\d+)/%s/$" % field,
                     self.admin_site.admin_view(view),
                     name=self._get_private_media_view_name(field),

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 1.11
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
+    Framework :: Django :: 3.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 
-from privates.storages import PrivateMediaFileSystemStorage, private_media_storage
+from privates.storages import (
+    PrivateMediaFileSystemStorage, private_media_storage
+)
 from privates.test import temp_private_root
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   py{35,36,37}-django111
   py35-django22
-  py{36,37,38}-django{22,30}
+  py{36,37,38}-django{22,32}
   isort
   docs
 skip_missing_interpreters = true
@@ -11,7 +11,7 @@ skip_missing_interpreters = true
 DJANGO =
   1.11: django111
   2.2: django22
-  3.0: django30
+  3.2: django32
 
 [testenv]
 extras =
@@ -20,7 +20,7 @@ extras =
 deps =
   django111: Django~=1.11.0
   django22: Django~=2.2.0
-  django30: Django~=3.0.0
+  django32: Django~=3.2.0
 commands =
   py.test \
     --cov-report=xml \


### PR DESCRIPTION
After upgrading a project to Django3.2, I noticed a deprecation warning for "url".
This commit removes that warning.